### PR TITLE
Build fails on lint error due to okio dep

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    // Allow basic build to proceed instead of error-ing due to InvalidPackage warning from Okio.
+    // Related issue: https://github.com/square/okio/issues/58
+    lintOptions {
+        disable 'InvalidPackage'
+   }
 }
 
 dependencies {


### PR DESCRIPTION
#### What's this PR do?

Changes "InvalidPackage" lint errors to a warning so that the build can proceed. This should allow someone to clone/download the repo, run `./gradlew build` and have it succeed. I've tested locally and it seems good.
#### How should this be manually tested?

Clone the repo, run `./gradlew build`.
#### Any background context you want to provide?

`./gradlew build` will fail due to a lint error caused by the inclusion of OkHttp/Okio. The error is something like:

```
Invalid package reference in library; not included in Android: java.nio.file.
Referenced from okio.Okio.
```

[Issue in the Okio repo documenting this](https://github.com/square/okio/issues/58) along with steps to lower the level of the flag to a "warning", which is what I've done here.

Granted, that affects the entire build, not just the one package. [Here's a similar proposed fix for a similar lint error](http://stackoverflow.com/questions/21827004/gradle-dagger-lint-ignore-by-package) via StackOverflow.
#### What are the relevant issues?

https://github.com/square/okio/issues/58
